### PR TITLE
Utilize Chrome storage to persist user dropdown selections 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,5 +10,8 @@
     "chrome_url_overrides": {
         "newtab": "index.html"
     },
+    "permissions": [
+        "storage"
+    ],
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'"
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "yargs": "^8.0.1"
   },
   "author": "Sebastian Liu",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
     "babel-repl": "0.0.7",
+    "babel-runtime": "^6.23.0",
     "css-loader": "^0.26.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "node-sass": "^4.3.0",
@@ -31,7 +32,8 @@
     "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
     "transform-runtime": "0.0.0",
-    "webpack": "^1.14.0"
+    "webpack": "^1.14.0",
+    "yargs": "^8.0.1"
   },
   "author": "Sebastian Liu",
   "license": "ISC"

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,8 +2,16 @@ import '../styles/site.scss';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Countdown from './Countdown';
+import { DROPDOWN_OPTIONS } from '../constants/DropdownOptions';
 
-ReactDOM.render(
-    <Countdown />,
-    document.getElementById('container')
-);
+chrome.storage.sync.get((value) => {
+    let timeOption = (value && value.timeOption) ? value.timeOption : DROPDOWN_OPTIONS.timeOptions.defaultValue;
+    let dateOption = DROPDOWN_OPTIONS.dateOptions.defaultValue;
+    ReactDOM.render(
+        <Countdown
+            timeOption={timeOption}
+            dateOption={dateOption}
+        />,
+        document.getElementById('container')
+    );
+});

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import { DROPDOWN_OPTIONS } from '../constants/DropdownOptions';
 
 chrome.storage.sync.get((value) => {
     let timeOption = (value && value.timeOption) ? value.timeOption : DROPDOWN_OPTIONS.timeOptions.defaultValue;
-    let dateOption = DROPDOWN_OPTIONS.dateOptions.defaultValue;
+    let dateOption = (value && value.dateOption) ? value.dateOption : DROPDOWN_OPTIONS.dateOptions.defaultValue;
     ReactDOM.render(
         <Countdown
             timeOption={timeOption}

--- a/src/components/Countdown.jsx
+++ b/src/components/Countdown.jsx
@@ -65,11 +65,12 @@ export default class Countdown extends Component {
                     customDropdownOption={
                         <CustomDateInput
                             onSubmit={(input) => {
+                                let customDate = CustomDateInputHelper.getCustomDate(input);
                                 this.setState({
                                     displayDateOption: false,
-                                    dateOption: CustomDateInputHelper.getCustomDate(input)
+                                    dateOption: customDate
                                 });
-                                chrome.storage.sync.set({"dateOption": input});
+                                chrome.storage.sync.set({"dateOption": customDate});
                             }}
                         />
                     }

--- a/src/components/Countdown.jsx
+++ b/src/components/Countdown.jsx
@@ -12,25 +12,15 @@ The desired text to display is:
 */
 export default class Countdown extends Component {
 
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             displayTimeOption: false,
             displayDateOption: false,
-            timeOption: DROPDOWN_OPTIONS.timeOptions.defaultValue,
-            dateOption: DROPDOWN_OPTIONS.dateOptions.defaultValue,
+            timeOption: props.timeOption,
+            dateOption: props.dateOption,
             now: Date.now()
         };
-    }
-
-    componentWillMount() {
-        chrome.storage.sync.get("timeOption", (value) => {
-            if (value && value.timeOption) {
-                this.setState({
-                    timeOption: value.timeOption
-                });
-            }
-        });
     }
 
     componentDidMount() {
@@ -79,6 +69,7 @@ export default class Countdown extends Component {
                                     displayDateOption: false,
                                     dateOption: CustomDateInputHelper.getCustomDate(input)
                                 });
+                                chrome.storage.sync.set({"dateOption": input});
                             }}
                         />
                     }
@@ -94,10 +85,16 @@ export default class Countdown extends Component {
                             displayDateOption: !this.state.displayDateOption,
                             dateOption: option
                         });
+                        chrome.storage.sync.set({"dateOption": option});
                     }}
                 />.
             </div>
         );
     }
 
+}
+
+Countdown.propTypes = {
+    timeOption: React.PropTypes.object.isRequired,
+    dateOption: React.PropTypes.object.isRequired
 }

--- a/src/components/Countdown.jsx
+++ b/src/components/Countdown.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { DROPDOWN_OPTIONS } from '../constants/DropdownOptions';
 import TimeCalculator from '../utils/TimeCalculator';
 import CountdownDisplay from './CountdownDisplay';
@@ -96,6 +97,6 @@ export default class Countdown extends Component {
 }
 
 Countdown.propTypes = {
-    timeOption: React.PropTypes.object.isRequired,
-    dateOption: React.PropTypes.object.isRequired
+    timeOption: PropTypes.object.isRequired,
+    dateOption: PropTypes.object.isRequired
 }

--- a/src/components/Countdown.jsx
+++ b/src/components/Countdown.jsx
@@ -23,6 +23,16 @@ export default class Countdown extends Component {
         };
     }
 
+    componentWillMount() {
+        chrome.storage.sync.get("timeOption", (value) => {
+            if (value && value.timeOption) {
+                this.setState({
+                    timeOption: value.timeOption
+                });
+            }
+        });
+    }
+
     componentDidMount() {
         setInterval(() => {
             this.setState({now: Date.now()});
@@ -46,14 +56,15 @@ export default class Countdown extends Component {
                         this.setState({
                             displayTimeOption: !this.state.displayTimeOption,
                             displayDateOption: false
-                        })
+                        });
                     }}
                     onSelect={(option) => {
                         this.setState({
                             displayTimeOption: !this.state.displayTimeOption,
                             displayDateOption: false,
                             timeOption: option
-                        })
+                        });
+                        chrome.storage.sync.set({"timeOption": option});
                     }}
                 />
                 &nbsp;remaining&nbsp;
@@ -67,7 +78,7 @@ export default class Countdown extends Component {
                                 this.setState({
                                     displayDateOption: false,
                                     dateOption: CustomDateInputHelper.getCustomDate(input)
-                                })
+                                });
                             }}
                         />
                     }
@@ -75,14 +86,14 @@ export default class Countdown extends Component {
                         this.setState({
                             displayTimeOption: false,
                             displayDateOption: !this.state.displayDateOption
-                        })
+                        });
                     }}
                     onSelect={(option) => {
                         this.setState({
                             displayTimeOption: false,
                             displayDateOption: !this.state.displayDateOption,
                             dateOption: option
-                        })
+                        });
                     }}
                 />.
             </div>

--- a/src/components/CountdownDisplay.jsx
+++ b/src/components/CountdownDisplay.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import TimeCalculator from '../utils/TimeCalculator';
 
 const CountdownDisplay = ({ timeOption, dateOption, now }) => {
@@ -12,9 +13,9 @@ const CountdownDisplay = ({ timeOption, dateOption, now }) => {
 };
 
 CountdownDisplay.propTypes = {
-    timeOption: React.PropTypes.object.isRequired,
-    dateOption: React.PropTypes.object.isRequired,
-    now: React.PropTypes.number.isRequired
+    timeOption: PropTypes.object.isRequired,
+    dateOption: PropTypes.object.isRequired,
+    now: PropTypes.number.isRequired
 };
 
 export default CountdownDisplay;

--- a/src/components/CustomDateInput.jsx
+++ b/src/components/CustomDateInput.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 export default class CustomDateInput extends Component {
 
@@ -32,5 +33,5 @@ export default class CustomDateInput extends Component {
 }
 
 CustomDateInput.propTypes = {
-    onSubmit: React.PropTypes.func.isRequired
+    onSubmit: PropTypes.func.isRequired
 }

--- a/src/components/Dropdown.jsx
+++ b/src/components/Dropdown.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const Dropdown = ({ shouldDisplay, displayOption, dropdownOptions, customDropdownOption, onDropdown, onSelect }) => {
 
@@ -28,12 +29,12 @@ const Dropdown = ({ shouldDisplay, displayOption, dropdownOptions, customDropdow
 };
 
 Dropdown.propTypes = {
-    shouldDisplay: React.PropTypes.bool.isRequired,
-    displayOption: React.PropTypes.object.isRequired,
-    dropdownOptions: React.PropTypes.object.isRequired,
-    customDropdownOption: React.PropTypes.object,
-    onDropdown: React.PropTypes.func.isRequired,
-    onSelect: React.PropTypes.func.isRequired
+    shouldDisplay: PropTypes.bool.isRequired,
+    displayOption: PropTypes.object.isRequired,
+    dropdownOptions: PropTypes.object.isRequired,
+    customDropdownOption: PropTypes.object,
+    onDropdown: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired
 };
 
 export default Dropdown;

--- a/src/constants/DateOptions.js
+++ b/src/constants/DateOptions.js
@@ -1,21 +1,15 @@
-import DateCalculator from '../utils/DateCalculator';
-
 export const TODAY = {
-    displayName: 'today',
-    endDate: DateCalculator.getStartOfTomorrow()
+    displayName: 'today'
 }
 
 export const WEEK = {
-    displayName: 'this week',
-    endDate: DateCalculator.getStartOfNextWeek()
+    displayName: 'this week'
 }
 
 export const MONTH = {
-    displayName: 'this month',
-    endDate: DateCalculator.getStartOfNextMonth()
+    displayName: 'this month'
 }
 
 export const YEAR = {
-    displayName: 'this year',
-    endDate: DateCalculator.getStartOfNextYear()
+    displayName: 'this year'
 }

--- a/src/utils/CustomDateInputHelper.js
+++ b/src/utils/CustomDateInputHelper.js
@@ -19,16 +19,11 @@ export default class CustomDateInputHelper {
         }
     }
 
-    static getDateFromDateString(date) {
-        let endDate = Date.parse(date);
-        return (!isNaN(endDate) && endDate > 0) ? new Date(date) : null;
-    }
-
     static getCustomDate(input) {
         let dateAndDescription = this.parseDescriptionAndDate(input);
         return {
             displayName: `until ${dateAndDescription.descriptionString} ${dateAndDescription.dateString ? "(" + dateAndDescription.dateString + ")" : ""}`.trim(),
-            endDate: this.getDateFromDateString(dateAndDescription.dateString)
+            endDate: dateAndDescription.dateString
         };
     }
 

--- a/src/utils/DateCalculator.js
+++ b/src/utils/DateCalculator.js
@@ -1,3 +1,5 @@
+import { TODAY, WEEK, MONTH, YEAR } from '../constants/DateOptions';
+
 export default class DateCalculator {
 
     static getStartOfTomorrow() {
@@ -38,6 +40,22 @@ export default class DateCalculator {
             1
         );
         return nextYear;
+    }
+
+    static getEndDateFromDateOption(dateOption) {
+        switch (dateOption.displayName) {
+            case TODAY.displayName:
+                return DateCalculator.getStartOfTomorrow();
+            case WEEK.displayName:
+                return DateCalculator.getStartOfNextWeek();
+            case MONTH.displayName:
+                return DateCalculator.getStartOfNextMonth();
+            case YEAR.displayName:
+                return DateCalculator.getStartOfNextYear();
+            default:
+                let endDate = Date.parse(dateOption);
+                return !isNaN(endDate)? new Date(dateOption) : null;
+        }
     }
 
 }

--- a/src/utils/TimeCalculator.js
+++ b/src/utils/TimeCalculator.js
@@ -1,16 +1,19 @@
+import DateCalculator from './DateCalculator';
+
 export default class TimeCalculator {
 
     static computeTimeRemaining(timeOption, dateOption, now) {
-        if (dateOption.endDate === null) {
+        let endDate = dateOption.endDate ? DateCalculator.getEndDateFromDateOption(dateOption.endDate) : DateCalculator.getEndDateFromDateOption(dateOption);
+        if (endDate === null) {
             return null;
         } else {
-            let ms = this.timeRemainingMill(dateOption, now);
+            let ms = this.timeRemainingMill(endDate, now);
             return ms / timeOption.convertFromMill;
         }
     }
 
-    static timeRemainingMill(dateOption, now) {
-        return dateOption.endDate - now;
+    static timeRemainingMill(endDate, now) {
+        return endDate - now;
     }
 
 }


### PR DESCRIPTION
Opening up a new tab will now reflect the user's previous dropdown selection for both `timeOption` and `dateOption`. Also using `prop-types` instead of `React.PropTypes`. 